### PR TITLE
Move database credentials to environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # WebApp
 berikut roadmap terstruktur untuk project MAN1HST — aplikasi sistem manajemen madrasah digital multi-role dengan fitur lengkap (absensi, pembayaran, data guru/siswa, integrasi Fitur lainnya)
+
+## Konfigurasi Lingkungan
+
+Buat file `.env` di root proyek untuk menyimpan kredensial database:
+
+```
+DB_HOST=localhost
+DB_NAME=absensi_db
+DB_USER=root
+DB_PASS=
+DB_CHARSET=utf8mb4
+```
+
+File `.env` sudah ditambahkan ke `.gitignore` dan tidak boleh dikomit ke repository.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "vlucas/phpdotenv": "^5.5"
+    }
+}

--- a/config.php
+++ b/config.php
@@ -1,9 +1,18 @@
 <?php
-$host = "localhost";
-$db   = "absensi_db";
-$user = "root";
-$pass = "";
-$charset = 'utf8mb4';
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
+if (class_exists(Dotenv\Dotenv::class)) {
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+    $dotenv->safeLoad();
+}
+
+$host = $_ENV['DB_HOST'] ?? 'localhost';
+$db   = $_ENV['DB_NAME'] ?? 'absensi_db';
+$user = $_ENV['DB_USER'] ?? 'root';
+$pass = $_ENV['DB_PASS'] ?? '';
+$charset = $_ENV['DB_CHARSET'] ?? 'utf8mb4';
 
 $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
 $options = [


### PR DESCRIPTION
## Summary
- Read database credentials from `.env` via phpdotenv in `config.php`
- Document environment variables and ignore `.env`/`vendor`
- Add `vlucas/phpdotenv` dependency

## Testing
- `php -l config.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689b99e48c34832b832449964c2f4954