### PR TITLE
Add deployment error report

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,0 +1,7 @@
+# Deployment Preparation Report
+
+## Composer install
+- Failed: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403.
+
+## PHP syntax check
+- All PHP files passed syntax check; no syntax errors detected.


### PR DESCRIPTION
## Summary
- document deployment preparation results
- note composer dependency install failure
- confirm PHP files pass syntax check

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_689ba67c6a84832bb8669ea26d2f8c61