### PR TITLE
Add CORS and env handling to attendance API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_NAME=absensi_db
+DB_USER=root
+DB_PASS=
+DB_CHARSET=utf8mb4
+ALLOWED_ORIGIN=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ DB_NAME=absensi_db
 DB_USER=root
 DB_PASS=
 DB_CHARSET=utf8mb4
+ALLOWED_ORIGIN=http://localhost:3000
 ```
 
 File `.env` sudah ditambahkan ke `.gitignore` dan tidak boleh dikomit ke repository.

--- a/api/absen.php
+++ b/api/absen.php
@@ -1,25 +1,47 @@
 <?php
-include('../db/config.php');
-$id = $_POST['id'];
-$tanggal = date('Y-m-d');
-$kelas = substr($id, 0, 1); // Asumsi ID berisi info kelas
+require_once __DIR__ . '/../config.php';
 
-$table = "absen_kelas_" . $kelas;
-$conn->query("CREATE TABLE IF NOT EXISTS $table (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    siswa_id VARCHAR(50),
-    tanggal DATE,
-    waktu TIME,
-    UNIQUE(siswa_id, tanggal)
-)");
+$origin = $_ENV['ALLOWED_ORIGIN'] ?? '*';
+header('Access-Control-Allow-Origin: ' . $origin);
+header('Access-Control-Allow-Headers: Content-Type, Authorization');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+header('Content-Type: application/json');
 
-$stmt = $conn->prepare("INSERT IGNORE INTO $table (siswa_id, tanggal, waktu) VALUES (?, ?, NOW())");
-$stmt->bind_param("ss", $id, $tanggal);
-$stmt->execute();
-
-if ($stmt->affected_rows > 0) {
-    echo "Absen berhasil!";
-} else {
-    echo "Sudah absen hari ini.";
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
 }
-?>
+
+$id = $_POST['id'] ?? null;
+if (!$id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'ID wajib diisi.']);
+    exit;
+}
+
+$tanggal = date('Y-m-d');
+$kelas   = substr($id, 0, 1);
+$table   = 'absen_kelas_' . $kelas;
+
+try {
+    $pdo->exec("CREATE TABLE IF NOT EXISTS `$table` (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        siswa_id VARCHAR(50),
+        tanggal DATE,
+        waktu TIME,
+        UNIQUE(siswa_id, tanggal)
+    )");
+
+    $stmt = $pdo->prepare("INSERT IGNORE INTO `$table` (siswa_id, tanggal, waktu) VALUES (?, ?, NOW())");
+    $stmt->execute([$id, $tanggal]);
+
+    if ($stmt->rowCount() > 0) {
+        echo json_encode(['message' => 'Absen berhasil!']);
+    } else {
+        echo json_encode(['message' => 'Sudah absen hari ini.']);
+    }
+} catch (PDOException $e) {
+    http_response_code(500);
+    error_log($e->getMessage());
+    echo json_encode(['error' => 'Terjadi kesalahan pada server.']);
+}


### PR DESCRIPTION
## Summary
- load environment and add CORS headers to attendance API
- return JSON responses with error handling
- document ALLOWED_ORIGIN and provide .env example

## Testing
- `php -l api/absen.php`
- `php -l config.php`
- ⚠️ `composer install` (failed: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)

------
https://chatgpt.com/codex/tasks/task_e_689ba58845d4832bb8fee854b0cf1724