### PR TITLE
Add deployment error report

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,0 +1,15 @@
+# Deployment Preparation Report
+
+## Composer install
+- Failed: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403.
+- No `vendor/` directory or `composer.lock` generated because dependencies were not installed.
+
+## Composer validate
+- `name` and `description` fields missing from `composer.json`.
+- No license specified; consider adding one or using `"proprietary"`.
+
+## Environment
+- No `.env` file detected; environment variables may not be configured.
+
+## PHP syntax check
+- All PHP files passed syntax check; no syntax errors detected.


### PR DESCRIPTION
## Summary
- document deployment preparation results
- note composer dependency install failure and missing vendor files
- record composer.json metadata issues and absent .env file

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `composer validate`
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689ba67c6a84832bb8669ea26d2f8c61