### PR TITLE
Add deployment error report

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,0 +1,15 @@
+# Laporan Persiapan Deployment
+
+## composer install
+- Gagal: curl error 56 saat mengunduh https://repo.packagist.org/packages.json, CONNECT tunnel failed, response 403.
+- Direktori `vendor/` dan berkas `composer.lock` tidak dibuat karena dependensi belum terpasang.
+
+## composer validate
+- Kolom `name` dan `description` pada `composer.json` belum diisi.
+- Lisensi belum ditentukan; tambahkan lisensi atau gunakan `"proprietary"`.
+
+## Lingkungan
+- Berkas `.env` tidak ditemukan; variabel lingkungan kemungkinan belum dikonfigurasi.
+
+## Pemeriksaan sintaks PHP
+- Semua berkas PHP lulus pemeriksaan sintaks; tidak ada kesalahan.


### PR DESCRIPTION
## Summary
- document deployment preparation results in Indonesian
- note composer dependency install failure and missing vendor files
- record composer.json metadata issues and absent .env file

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `composer validate`
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`
- `ls vendor` *(fails: No such file or directory)*
- `stat .env` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ba67c6a84832bb8669ea26d2f8c61